### PR TITLE
Correct The Coming of Conan reading status to Finished

### DIFF
--- a/readings/2019-04-28-01-the-coming-of-conan-the-cimmerian-by-robert-e-howard.md
+++ b/readings/2019-04-28-01-the-coming-of-conan-the-cimmerian-by-robert-e-howard.md
@@ -27,5 +27,5 @@ timeline:
   - date: 2019-04-27
     progress: 70%
   - date: 2019-04-28
-    progress: Abandoned
+    progress: Finished
 ---


### PR DESCRIPTION
## Summary
Corrects the reading status for "The Coming of Conan the Cimmerian" from "Abandoned" to "Finished".

## Issue
The reading was incorrectly marked as "Abandoned" when it was actually completed according to the Goodreads review (https://www.goodreads.com/review/show/363878825), which shows it was finished and rated 4 stars.

## Fix
Changed the final progress entry from "Abandoned" to "Finished" to accurately reflect the actual reading status.

## Verification
✅ Data export continues to work correctly with the "Finished" status
✅ All quality checks pass

🤖 Generated with [Claude Code](https://claude.ai/code)