### PR TITLE
fix: correct RadioList attribute name mismatch

### DIFF
--- a/booklog/cli/radio_list.py
+++ b/booklog/cli/radio_list.py
@@ -32,7 +32,7 @@ class RadioList[T]:
 
     def __init__(self, options: Sequence[tuple[T, AnyFormattedText]]) -> None:
         self.options = options
-        self.current_option: T = options[0][0]
+        self.current_value: T | None = None
         self._selected_index = 0
 
         # Key bindings.


### PR DESCRIPTION
## Summary
- Fixed AttributeError crash when selecting any menu option
- Corrected attribute name from `current_option` to `current_value` to match usage
- Set initial value to `None` to properly represent no selection state

## Test plan
- [x] Run `uv run pytest` - all tests pass
- [x] Run `uv run mypy .` - no type errors
- [x] Run `uv run ruff check .` - all checks pass
- [x] Run `npm run format` - formatting check passes

🤖 Generated with [Claude Code](https://claude.ai/code)