### PR TITLE
fix: simplify authors_with_reviews data structure

### DIFF
--- a/booklog/exports/api.py
+++ b/booklog/exports/api.py
@@ -1,14 +1,12 @@
 from __future__ import annotations
 
-from collections import defaultdict
-
 from booklog.exports import authors, reviewed_works, stats, timeline_entries
 from booklog.exports.repository_data import RepositoryData
 from booklog.repository import api as repository_api
 
 
 def export_data() -> None:
-    authors_with_reviews: dict[str, list[repository_api.Author]] =  defaultdict(list)
+    authors_with_reviews: set[str] = set()
 
     works = list(repository_api.works())
     reviews = list(repository_api.reviews())
@@ -16,7 +14,7 @@ def export_data() -> None:
 
     for author in all_authors:
         if any(work.review(reviews) for work in author.works(works)):
-            authors_with_reviews[author.slug].append(author)
+            authors_with_reviews.add(author.slug)
 
 
     repository_data = RepositoryData(

--- a/booklog/exports/repository_data.py
+++ b/booklog/exports/repository_data.py
@@ -6,7 +6,7 @@ from booklog.repository import api as repository_api
 @dataclass
 class RepositoryData:
     authors: list[repository_api.Author]
-    authors_with_reviews: dict[str, list[repository_api.Author]]
+    authors_with_reviews: set[str]
     works: list[repository_api.Work]
     readings: list[repository_api.Reading]
     reviews: list[repository_api.Review]


### PR DESCRIPTION
## Summary
- Changed `authors_with_reviews` from `dict[str, list[Author]]` to `set[str]`
- Removed unnecessary `defaultdict` import
- Fixed logic error in data population

## Problem
The code was using a `defaultdict(list)` and appending authors to lists, but:
1. Each author slug is unique and only appears once
2. The consuming code only checks if a slug exists (`if author_slug in repository_data.authors_with_reviews`)
3. The list structure was never utilized

This created unnecessary memory overhead and complexity.

## Solution
Simplified to use a `set[str]` which:
- Only stores unique author slugs
- Provides O(1) lookup for checking if an author has reviews
- Matches the actual usage pattern in the codebase

## Test plan
- [x] Run `uv run pytest` - all tests pass
- [x] Run `uv run mypy .` - no type errors
- [x] Run `uv run ruff check .` - all checks pass
- [x] Run `npm run format` - formatting check passes

🤖 Generated with [Claude Code](https://claude.ai/code)