### PR TITLE
Refactor exports to share TypedDict definitions

### DIFF
--- a/booklog/exports/json_author.py
+++ b/booklog/exports/json_author.py
@@ -1,0 +1,7 @@
+from typing import TypedDict
+
+
+class JsonAuthor(TypedDict):
+    name: str
+    sortName: str
+    slug: str

--- a/booklog/exports/json_author_with_reviewed_works.py
+++ b/booklog/exports/json_author_with_reviewed_works.py
@@ -1,0 +1,6 @@
+from booklog.exports.json_author import JsonAuthor
+from booklog.exports.json_reviewed_work import JsonReviewedWork
+
+
+class JsonAuthorWithReviewedWorks(JsonAuthor):
+    reviewedWorks: list[JsonReviewedWork]

--- a/booklog/exports/json_maybe_reviewed_work.py
+++ b/booklog/exports/json_maybe_reviewed_work.py
@@ -1,0 +1,10 @@
+import datetime
+
+from booklog.exports.json_work import JsonWork
+
+
+class JsonMaybeReviewedWork(JsonWork):
+    grade: str | None
+    gradeValue: int | None
+    reviewDate: datetime.date | None
+    yearReviewed: int | None

--- a/booklog/exports/json_reviewed_work.py
+++ b/booklog/exports/json_reviewed_work.py
@@ -1,0 +1,11 @@
+import datetime
+
+from booklog.exports.json_work import JsonWork
+
+
+class JsonReviewedWork(JsonWork):
+    reviewSequence: str
+    grade: str
+    gradeValue: int
+    reviewDate: datetime.date
+    yearReviewed: int

--- a/booklog/exports/json_work.py
+++ b/booklog/exports/json_work.py
@@ -1,0 +1,14 @@
+from typing import TypedDict
+
+from booklog.exports.json_work_author import JsonWorkAuthor
+
+
+class JsonWork(TypedDict):
+    title: str
+    subtitle: str | None
+    sortTitle: str
+    yearPublished: str
+    authors: list[JsonWorkAuthor]
+    kind: str
+    slug: str
+    includedInSlugs: list[str]

--- a/booklog/exports/json_work_author.py
+++ b/booklog/exports/json_work_author.py
@@ -1,12 +1,8 @@
-from typing import TypedDict
-
+from booklog.exports.json_author import JsonAuthor
 from booklog.repository import api as repository_api
 
 
-class JsonWorkAuthor(TypedDict):
-    name: str
-    sortName: str
-    slug: str
+class JsonWorkAuthor(JsonAuthor):
     notes: str | None
 
 

--- a/booklog/exports/stats.py
+++ b/booklog/exports/stats.py
@@ -10,7 +10,7 @@ from booklog.utils.logging import logger
 
 
 class JsonMostReadAuthorReading(TypedDict):
-    sequence: int
+    readingSequence: int
     date: date
     slug: str
     edition: str
@@ -125,7 +125,7 @@ def _build_json_most_read_author_reading(
     reviewed = bool(work.review(repository_data.reviews))
 
     return JsonMostReadAuthorReading(
-        sequence=reading.sequence,
+        readingSequence=reading.sequence,
         date=_date_finished_or_abandoned(reading=reading),
         slug=work.slug,
         edition=reading.edition,
@@ -141,7 +141,7 @@ def _build_json_most_read_author_reading(
 
 
 def _reading_sort_key(reading: JsonMostReadAuthorReading) -> str:
-    return "{}-{}".format(reading["date"], reading["sequence"])
+    return "{}-{}".format(reading["date"], reading["readingSequence"])
 
 
 def _build_most_read_authors(

--- a/booklog/exports/utils.py
+++ b/booklog/exports/utils.py
@@ -1,0 +1,25 @@
+from booklog.exports.repository_data import RepositoryData
+from booklog.repository import api as repository_api
+
+
+def build_review_sequence(
+    review: repository_api.Review, repository_data: RepositoryData
+) -> str:
+    """Build a review sequence string from review and repository data.
+
+    Finds the most recent reading for the reviewed work and combines
+    it with the review date to create a unique sequence identifier.
+
+    Raises an error if no reading is found for the reviewed work.
+    """
+    work = review.work(repository_data.works)
+    readings = list(work.readings(repository_data.readings))
+
+    if not readings:
+        raise ValueError(f"No readings found for reviewed work: {work.title}")
+
+    most_recent_reading = sorted(
+        readings, key=lambda reading: reading.sequence, reverse=True
+    )[0]
+
+    return f"{review.date}-{most_recent_reading.sequence}"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -112,6 +112,17 @@ flake8-quotes.inline-quotes = "double"
 pydocstyle.convention = "google"
 pylint.max-args = 6
 
+[tool.ruff.lint.per-file-ignores]
+"booklog/exports/json_*.py" = ["N815"] # Allow camelCase in JSON TypedDicts
+"booklog/exports/authors.py" = ["N815"] # Allow camelCase in JSON TypedDicts
+"booklog/exports/reviewed_works.py" = [
+  "N815",
+] # Allow camelCase in JSON TypedDicts
+"booklog/exports/stats.py" = ["N815"] # Allow camelCase in JSON TypedDicts
+"booklog/exports/timeline_entries.py" = [
+  "N815",
+] # Allow camelCase in JSON TypedDicts
+
 [tool.mypy]
 python_version = "3.13"
 strict = true

--- a/tests/exports/__snapshots__/test_api/test_exports_authors.json
+++ b/tests/exports/__snapshots__/test_api/test_exports_authors.json
@@ -14,10 +14,14 @@
       "gradeValue": 13,
       "includedInSlugs": [],
       "kind": "Nonfiction",
+      "reviewDate": "2016-03-10",
+      "reviewSequence": "2016-03-10-1",
       "slug": "on-writing-by-stephen-king",
       "sortTitle": "On Writing: A Memoir of the Craft",
+      "subtitle": "A Memoir of the Craft",
       "title": "On Writing",
-      "yearPublished": "2000"
+      "yearPublished": "2000",
+      "yearReviewed": 2016
     }
   ],
   "slug": "stephen-king",

--- a/tests/exports/__snapshots__/test_api/test_exports_reading_timeline_entries.json
+++ b/tests/exports/__snapshots__/test_api/test_exports_reading_timeline_entries.json
@@ -2,54 +2,57 @@
   {
     "authors": [
       {
-        "name": "Stephen King"
+        "name": "Stephen King",
+        "slug": "stephen-king",
+        "sortName": "King, Stephen"
       }
     ],
-    "date": "2016-03-12",
     "edition": "Kindle",
     "includedInSlugs": [],
     "kind": "Nonfiction",
     "progress": "Finished",
-    "readingYear": "2016",
     "reviewed": true,
-    "sequence": "2016-03-12-2016-03-12-1",
     "slug": "on-writing-by-stephen-king",
+    "timelineDate": "2016-03-12",
+    "timelineSequence": "2016-03-12-2016-03-12-1",
     "title": "On Writing",
     "yearPublished": "2000"
   },
   {
     "authors": [
       {
-        "name": "Stephen King"
+        "name": "Stephen King",
+        "slug": "stephen-king",
+        "sortName": "King, Stephen"
       }
     ],
-    "date": "2016-03-11",
     "edition": "Kindle",
     "includedInSlugs": [],
     "kind": "Nonfiction",
     "progress": "50%",
-    "readingYear": "2016",
     "reviewed": true,
-    "sequence": "2016-03-11-2016-03-12-1",
     "slug": "on-writing-by-stephen-king",
+    "timelineDate": "2016-03-11",
+    "timelineSequence": "2016-03-11-2016-03-12-1",
     "title": "On Writing",
     "yearPublished": "2000"
   },
   {
     "authors": [
       {
-        "name": "Stephen King"
+        "name": "Stephen King",
+        "slug": "stephen-king",
+        "sortName": "King, Stephen"
       }
     ],
-    "date": "2016-03-10",
     "edition": "Kindle",
     "includedInSlugs": [],
     "kind": "Nonfiction",
     "progress": "15%",
-    "readingYear": "2016",
     "reviewed": true,
-    "sequence": "2016-03-10-2016-03-12-1",
     "slug": "on-writing-by-stephen-king",
+    "timelineDate": "2016-03-10",
+    "timelineSequence": "2016-03-10-2016-03-12-1",
     "title": "On Writing",
     "yearPublished": "2000"
   }

--- a/tests/exports/__snapshots__/test_api/test_exports_reviewed_works.json
+++ b/tests/exports/__snapshots__/test_api/test_exports_reviewed_works.json
@@ -8,7 +8,6 @@
         "sortName": "King, Stephen"
       }
     ],
-    "date": "2016-03-10",
     "grade": "A+",
     "gradeValue": 13,
     "includedInSlugs": [],
@@ -21,11 +20,12 @@
         "abandoned": false,
         "date": "2016-03-12",
         "isAudiobook": false,
-        "readingTime": 3,
-        "sequence": 1
+        "readingSequence": 1,
+        "readingTime": 3
       }
     ],
-    "sequence": "2016-03-10-1",
+    "reviewDate": "2016-03-10",
+    "reviewSequence": "2016-03-10-1",
     "slug": "on-writing-by-stephen-king",
     "sortTitle": "On Writing: A Memoir of the Craft",
     "subtitle": "A Memoir of the Craft",


### PR DESCRIPTION
## Summary
This PR refactors the export modules to share TypedDict definitions, reducing code duplication and improving consistency across the codebase.

## Changes

### Extract shared TypedDict definitions
Created separate files for commonly used type definitions:
- `JsonAuthor`: Base author type with name, sortName, slug
- `JsonWork`: Base work type with all common work fields  
- `JsonReviewedWork`: Extends JsonWork with review fields
- `JsonMaybeReviewedWork`: Extends JsonWork with optional review fields
- `JsonAuthorWithReviewedWorks`: Composite type for author with reviewed works

### Extract shared logic
- Created `utils.build_review_sequence()` to centralize review sequence logic
- Enforces business rule that reviews always have readings
- Throws error if no reading found for reviewed work

### Improve field naming consistency
- `sequence` → `reviewSequence` in JsonReviewedWork
- `date` → `reviewDate` in JsonReviewedWork/JsonMaybeReviewedWork
- `sequence` → `readingSequence` in JsonReading (stats.py)
- `date` → `timelineDate`, `sequence` → `timelineSequence` in JsonTimelineEntry
- Removed `readingYear` from JsonTimelineEntry (derivable from date)

### Eliminate redundant definitions
- Removed empty `JsonMoreReview` class
- Replaced `JsonIncludedWorkAuthor` with `JsonWorkAuthor`
- Replaced `JsonTimelineEntryAuthor` with `JsonAuthor`
- Use `JsonAuthorWithReviewedWorks` directly instead of empty subclass
- Updated `JsonWorkAuthor` to inherit from `JsonAuthor`

## Test plan
✅ All tests pass
✅ Type checking passes (mypy)
✅ Linting passes (ruff)
✅ Formatting verified (prettier)

🤖 Generated with [Claude Code](https://claude.ai/code)