### PR TITLE
fix: add missing IMDB ID for Pretty in Pink reference

### DIFF
--- a/reviews/fast-forward-by-stephen-morris.md
+++ b/reviews/fast-forward-by-stephen-morris.md
@@ -78,7 +78,7 @@ The band’s ascension to super-stardom takes its toll. Morris recounts a layove
 
 Morris’s blow-up was due, in part, to the stress of touring, but also to the Haçienda, Factory’s ever-hungry money-pit. Determined buck trends, the operators kept the club open seven nights a week. Most nights, it went empty.
 
-Another contributor was the band’s growing drug use. They worked with producer John Robie on “Shellshock” for the <span data-imdb-id="">_Pretty in Pink_</span> soundtrack.
+Another contributor was the band's growing drug use. They worked with producer John Robie on "Shellshock" for the <span data-imdb-id="tt0091790">_Pretty in Pink_</span> soundtrack.
 
 > It is widely acknowledged that cocaine may kill you, but you’re more likely to bore everyone else to death before it does. It will turn you into a self-obsessed, monstrous, gurning, yakking idiot.
 >


### PR DESCRIPTION
## Summary
- Added missing IMDB ID (tt0091790) to the Pretty in Pink movie reference in Fast Forward review

## Test plan
- [x] Verified the IMDB ID attribute is now properly populated
- [x] Consistent with other movie references in the file

🤖 Generated with [Claude Code](https://claude.ai/code)