### PR TITLE
feat: add NonEmptyList type to enforce works always have authors

### DIFF
--- a/booklog/cli/add_work.py
+++ b/booklog/cli/add_work.py
@@ -10,6 +10,7 @@ from prompt_toolkit.shortcuts import confirm
 from booklog.cli import ask, radio_list, select_author, select_work
 from booklog.cli.utils.array_to_sentence import array_to_sentence
 from booklog.repository import api as repository_api
+from booklog.repository.types import NonEmptyList
 
 Stages = Literal[
     "ask_for_authors",
@@ -59,7 +60,7 @@ def persist_work(state: State) -> State:
 
     repository_api.create_work(
         title=state.title,
-        work_authors=state.work_authors,
+        work_authors=NonEmptyList.from_sequence(state.work_authors),
         subtitle=state.subtitle,
         year=state.year_published,
         kind=state.kind,

--- a/booklog/exports/repository_data.py
+++ b/booklog/exports/repository_data.py
@@ -32,10 +32,8 @@ class RepositoryData:
         """
 
         def get_sort_key(work: repository_api.Work) -> str:
-            first_author_sort_name = ""
-            if work.work_authors:
-                first_author = work.work_authors[0].author(self.authors)
-                first_author_sort_name = first_author.sort_name
+            first_author = work.work_authors[0].author(self.authors)
+            first_author_sort_name = first_author.sort_name
             return f"{work.year}-{first_author_sort_name}-{work.sort_title}"
 
         sorted_works = sorted(self.works, key=get_sort_key)
@@ -49,10 +47,8 @@ class RepositoryData:
         """
 
         def get_sort_key(work: repository_api.Work) -> str:
-            first_author_sort_name = ""
-            if work.work_authors:
-                first_author = work.work_authors[0].author(self.authors)
-                first_author_sort_name = first_author.sort_name
+            first_author = work.work_authors[0].author(self.authors)
+            first_author_sort_name = first_author.sort_name
             return f"{first_author_sort_name}-{work.year}-{work.sort_title}"
 
         sorted_works = sorted(self.works, key=get_sort_key)
@@ -66,10 +62,8 @@ class RepositoryData:
         """
 
         def get_sort_key(work: repository_api.Work) -> str:
-            first_author_sort_name = ""
-            if work.work_authors:
-                first_author = work.work_authors[0].author(self.authors)
-                first_author_sort_name = first_author.sort_name
+            first_author = work.work_authors[0].author(self.authors)
+            first_author_sort_name = first_author.sort_name
             return f"{work.sort_title}-{first_author_sort_name}-{work.year}"
 
         sorted_works = sorted(self.works, key=get_sort_key)

--- a/booklog/repository/api.py
+++ b/booklog/repository/api.py
@@ -6,6 +6,7 @@ from dataclasses import dataclass
 from typing import Literal, cast
 
 from booklog.repository import json_authors, json_works, markdown_readings, markdown_reviews
+from booklog.repository.types import NonEmptyList
 
 WORK_KINDS = json_works.KINDS
 
@@ -64,7 +65,7 @@ class Work:
     slug: str
     kind: Kind
     included_work_slugs: list[str]
-    work_authors: list[WorkAuthor]
+    work_authors: NonEmptyList[WorkAuthor]
 
     def included_works(self, cache: list[Work] | None = None) -> Iterable[Work]:
         works_iterable = cache or works()
@@ -197,7 +198,7 @@ def create_work(
     title: str,
     subtitle: str | None,
     year: str,
-    work_authors: list[WorkAuthor],
+    work_authors: NonEmptyList[WorkAuthor],
     kind: Kind,
     included_work_slugs: list[str] | None = None,
 ) -> Work:
@@ -267,10 +268,10 @@ def _hydrate_json_work(json_work: json_works.JsonWork) -> Work:
         year=json_work["year"],
         kind=json_work["kind"],
         included_work_slugs=json_work["includedWorks"],
-        work_authors=[
+        work_authors=NonEmptyList.from_sequence([
             WorkAuthor(author_slug=work_author["slug"], notes=work_author["notes"])
             for work_author in json_work["authors"]
-        ],
+        ]),
     )
 
 

--- a/booklog/repository/types.py
+++ b/booklog/repository/types.py
@@ -1,0 +1,36 @@
+"""Custom types for the repository layer."""
+
+from collections.abc import Sequence
+from typing import TypeVar, overload
+
+T = TypeVar("T")
+
+
+class NonEmptyList[T](list[T]):
+    """A list that must contain at least one element.
+
+    This type ensures at compile-time that lists cannot be empty,
+    eliminating the need for runtime empty checks.
+    """
+
+    @overload
+    def __init__(self, first: T, /) -> None: ...
+
+    @overload
+    def __init__(self, first: T, /, *rest: T) -> None: ...
+
+    def __init__(self, first: T, /, *rest: T) -> None:
+        """Initialize with at least one required element."""
+        super().__init__([first, *rest])
+
+    @classmethod
+    def from_sequence(cls, seq: Sequence[T]) -> "NonEmptyList[T]":
+        """Create from a sequence, raising ValueError if empty."""
+        if not seq:
+            raise ValueError("Cannot create NonEmptyList from empty sequence")
+        first, *rest = seq
+        return cls(first, *rest)
+
+    def __bool__(self) -> bool:
+        """NonEmptyList is always truthy."""
+        return True

--- a/tests/cli/test_add_reading.py
+++ b/tests/cli/test_add_reading.py
@@ -6,6 +6,7 @@ from pytest_mock import MockerFixture
 
 from booklog.cli import add_reading
 from booklog.repository import api as repository_api
+from booklog.repository.types import NonEmptyList
 from tests.cli.conftest import MockInput
 from tests.cli.keys import Backspace, Escape
 from tests.cli.prompt_utils import ConfirmType, enter_text, select_option
@@ -36,12 +37,12 @@ def work_fixture(author_fixture: repository_api.Author) -> repository_api.Work:
         year="1980",
         kind="Novel",
         included_work_slugs=[],
-        work_authors=[
+        work_authors=NonEmptyList(
             repository_api.WorkAuthor(
                 author_slug=author_fixture.slug,
                 notes=None,
             )
-        ],
+        ),
     )
 
 

--- a/tests/cli/test_add_work.py
+++ b/tests/cli/test_add_work.py
@@ -5,6 +5,7 @@ from pytest_mock import MockerFixture
 
 from booklog.cli import add_work
 from booklog.repository import api as repository_api
+from booklog.repository.types import NonEmptyList
 from tests.cli.conftest import MockInput
 from tests.cli.keys import Escape
 from tests.cli.prompt_utils import ConfirmType, enter_text, select_option
@@ -28,12 +29,12 @@ def work_fixture(author_fixture: repository_api.Author) -> repository_api.Work:
         year="1980",
         kind="Novel",
         included_work_slugs=[],
-        work_authors=[
+        work_authors=NonEmptyList(
             repository_api.WorkAuthor(
                 author_slug=author_fixture.slug,
                 notes=None,
             )
-        ],
+        ),
     )
 
 
@@ -96,12 +97,12 @@ def test_calls_create_work(
     mock_create_work.assert_called_once_with(
         title="The Cellar",
         subtitle=None,
-        work_authors=[
+        work_authors=NonEmptyList(
             repository_api.WorkAuthor(
                 author_slug=author_fixture.slug,
                 notes=None,
             )
-        ],
+        ),
         year="1980",
         kind="Novel",
         included_work_slugs=[],
@@ -135,12 +136,12 @@ def test_calls_create_work_for_collection(
     mock_create_work.assert_called_once_with(
         title="The Richard Laymon Collection Volume 1",
         subtitle=None,
-        work_authors=[
+        work_authors=NonEmptyList(
             repository_api.WorkAuthor(
                 author_slug=author_fixture.slug,
                 notes=None,
             )
-        ],
+        ),
         year="2006",
         kind="Collection",
         included_work_slugs=[work_fixture.slug],

--- a/tests/exports/test_api.py
+++ b/tests/exports/test_api.py
@@ -8,6 +8,7 @@ from syrupy.extensions.json import JSONSnapshotExtension
 
 from booklog.exports import api as exports_api
 from booklog.repository import api as repository_api
+from booklog.repository.types import NonEmptyList
 
 
 @pytest.fixture(autouse=True)
@@ -18,12 +19,12 @@ def init_data() -> None:
         title="On Writing",
         subtitle="A Memoir of the Craft",
         year="2000",
-        work_authors=[
+        work_authors=NonEmptyList(
             repository_api.WorkAuthor(
                 author_slug=author.slug,
                 notes=None,
             )
-        ],
+        ),
         kind="Nonfiction",
     )
 
@@ -31,12 +32,12 @@ def init_data() -> None:
         title="The Stand",
         subtitle=None,
         year="1978",
-        work_authors=[
+        work_authors=NonEmptyList(
             repository_api.WorkAuthor(
                 author_slug=author.slug,
                 notes=None,
             )
-        ],
+        ),
         kind="Novel",
     )
 

--- a/tests/repository/test_api.py
+++ b/tests/repository/test_api.py
@@ -7,6 +7,7 @@ from syrupy.assertion import SnapshotAssertion
 from syrupy.extensions.json import JSONSnapshotExtension
 
 from booklog.repository import api as repository_api
+from booklog.repository.types import NonEmptyList
 
 
 @pytest.fixture
@@ -27,12 +28,12 @@ def work_fixture(author_fixture: repository_api.Author) -> repository_api.Work:
         year="1980",
         kind="Novel",
         included_work_slugs=[],
-        work_authors=[
+        work_authors=NonEmptyList(
             repository_api.WorkAuthor(
                 author_slug=author_fixture.slug,
                 notes=None,
             )
-        ],
+        ),
     )
 
 
@@ -57,12 +58,12 @@ def test_create_create_work(
         title="The Cellar",
         subtitle=None,
         year="1980",
-        work_authors=[
+        work_authors=NonEmptyList(
             repository_api.WorkAuthor(
                 author_slug=author_fixture.slug,
                 notes=None,
             )
-        ],
+        ),
         kind="Novel",
     )
 


### PR DESCRIPTION
## Summary

- Introduced a `NonEmptyList[T]` generic type that requires at least one element at construction time
- Updated the `Work` dataclass to use `NonEmptyList[WorkAuthor]` instead of `list[WorkAuthor]`
- Removed unnecessary guard clauses that were checking for empty `work_authors` lists

## Benefits

This change provides compile-time safety guaranteeing that works will always have at least one author, eliminating the need for defensive runtime checks. The type system now enforces this invariant, making the code more robust and removing three guard clauses from `repository_data.py`.

## Changes

1. **New type**: Created `booklog/repository/types.py` with the `NonEmptyList[T]` implementation
2. **Updated Work model**: Changed `work_authors` field to use `NonEmptyList[WorkAuthor]`
3. **Updated call sites**: Modified all Work creation sites to use `NonEmptyList`
4. **Updated tests**: All test files now create works with `NonEmptyList`
5. **Removed guard clauses**: Eliminated three `if work.work_authors:` checks in `repository_data.py`

## Test Plan

✅ All existing tests pass
✅ Type checking passes (`mypy`)
✅ Linting passes (`ruff`)
✅ Formatting passes (`prettier`)

🤖 Generated with [Claude Code](https://claude.ai/code)