### PR TITLE
refactor(exports): rename yearReviewed to reviewYear

### DIFF
--- a/booklog/exports/authors.py
+++ b/booklog/exports/authors.py
@@ -26,7 +26,7 @@ def _build_json_author_reviewed_work(
         gradeValue=review.grade_value,
         gradeSequence=repository_data.grade_sequence_map.get(work.slug, 0),
         reviewDate=review.date,
-        yearReviewed=review.date.year,
+        reviewYear=review.date.year,
         authors=[
             json_work_author.build_json_work_author(
                 work_author=work_author, all_authors=repository_data.authors

--- a/booklog/exports/json_maybe_reviewed_work.py
+++ b/booklog/exports/json_maybe_reviewed_work.py
@@ -7,4 +7,4 @@ class JsonMaybeReviewedWork(JsonWork):
     grade: str | None
     gradeValue: int | None
     reviewDate: datetime.date | None
-    yearReviewed: int | None
+    reviewYear: int | None

--- a/booklog/exports/json_reviewed_work.py
+++ b/booklog/exports/json_reviewed_work.py
@@ -9,4 +9,4 @@ class JsonReviewedWork(JsonWork):
     gradeValue: int
     gradeSequence: int
     reviewDate: datetime.date
-    yearReviewed: int
+    reviewYear: int

--- a/booklog/exports/reviewed_works.py
+++ b/booklog/exports/reviewed_works.py
@@ -66,7 +66,7 @@ def _build_json_more_review(
         gradeValue=review.grade_value,
         gradeSequence=repository_data.grade_sequence_map.get(work.slug, 0),
         reviewDate=review.date,
-        yearReviewed=review.date.year,
+        reviewYear=review.date.year,
         includedInSlugs=[
             included_in_work.slug
             for included_in_work in work.included_in_works(repository_data.works)
@@ -206,7 +206,7 @@ def _build_json_included_work(
         grade=review.grade if review else None,
         gradeValue=review.grade_value if review else None,
         reviewDate=review.date if review else None,
-        yearReviewed=review.date.year if review else None,
+        reviewYear=review.date.year if review else None,
         kind=included_work.kind,
         workYear=included_work.year,
         workYearSequence=repository_data.work_year_sequence_map.get(included_work.slug, 0),
@@ -263,7 +263,7 @@ def _build_json_reviewed_work(
             included_in_work.slug
             for included_in_work in work.included_in_works(repository_data.works)
         ],
-        yearReviewed=review.date.year,
+        reviewYear=review.date.year,
         moreByAuthors=more_by_authors,
         moreReviews=more_reviews,
         includedWorks=[

--- a/tests/exports/__snapshots__/test_api/test_exports_authors.json
+++ b/tests/exports/__snapshots__/test_api/test_exports_authors.json
@@ -18,14 +18,14 @@
       "kind": "Nonfiction",
       "reviewDate": "2016-03-10",
       "reviewSequence": 1,
+      "reviewYear": 2016,
       "slug": "on-writing-by-stephen-king",
       "sortTitle": "On Writing: A Memoir of the Craft",
       "subtitle": "A Memoir of the Craft",
       "title": "On Writing",
       "titleSequence": 1,
       "workYear": "2000",
-      "workYearSequence": 2,
-      "yearReviewed": 2016
+      "workYearSequence": 2
     }
   ],
   "slug": "stephen-king",

--- a/tests/exports/__snapshots__/test_api/test_exports_reviewed_works.json
+++ b/tests/exports/__snapshots__/test_api/test_exports_reviewed_works.json
@@ -28,13 +28,13 @@
     ],
     "reviewDate": "2016-03-10",
     "reviewSequence": 1,
+    "reviewYear": 2016,
     "slug": "on-writing-by-stephen-king",
     "sortTitle": "On Writing: A Memoir of the Craft",
     "subtitle": "A Memoir of the Craft",
     "title": "On Writing",
     "titleSequence": 1,
     "workYear": "2000",
-    "workYearSequence": 2,
-    "yearReviewed": 2016
+    "workYearSequence": 2
   }
 ]


### PR DESCRIPTION
## Summary
- Renamed `yearReviewed` field to `reviewYear` across all export-related dataclasses
- Updated all references in `reviewed_works.py`, `authors.py`, `json_reviewed_work.py`, and `json_maybe_reviewed_work.py`
- Updated test snapshots to reflect the new field name

## Test plan
✅ All tests pass (`uv run pytest`)
✅ Type checking passes (`uv run mypy .`)
✅ Linting passes (`uv run ruff check .`)
✅ Formatting is correct (`npm run format`)

🤖 Generated with [Claude Code](https://claude.ai/code)